### PR TITLE
broadcom-bluetooth: Fix building without vendored make_install macro

### DIFF
--- a/broadcom-bluetooth/Makefile
+++ b/broadcom-bluetooth/Makefile
@@ -30,7 +30,7 @@ brcm_patchram_plus : brcm_patchram_plus.o
 brcm_patchram_plus_usb : brcm_patchram_plus_usb.o
 
 install:
-	mkdir -p $(INSTALL_ROOT)/usr/sbin
-	install brcm_patchram_plus $(INSTALL_ROOT)/usr/sbin
-	install brcm_patchram_plus_h5 $(INSTALL_ROOT)/usr/sbin
-	install brcm_patchram_plus_usb $(INSTALL_ROOT)/usr/sbin
+	mkdir -p $(DESTDIR)/usr/sbin
+	install brcm_patchram_plus $(DESTDIR)/usr/sbin
+	install brcm_patchram_plus_h5 $(DESTDIR)/usr/sbin
+	install brcm_patchram_plus_usb $(DESTDIR)/usr/sbin

--- a/rpm/broadcom-bluetooth-bluez5.spec
+++ b/rpm/broadcom-bluetooth-bluez5.spec
@@ -14,17 +14,15 @@ Obsoletes: broadcom-bluetooth <= 1.0.4
 Broadcom Bluetooth utilities
 
 %prep
-%setup -q -n %{name}-%{version}/broadcom-bluetooth
+%autosetup -n %{name}-%{version}/broadcom-bluetooth
 
 %build
-make
+%make_build
 
 %install
-rm -rf %{buildroot}
 %make_install
 
 %files
-%defattr(-,root,root,-)
 %{_sbindir}/brcm_patchram_plus
 %{_sbindir}/brcm_patchram_plus_h5
 %{_sbindir}/brcm_patchram_plus_usb


### PR DESCRIPTION
Cleanup spec.

[broadcom-bluetooth] Fix building without vendored make_install macro. JB#55344